### PR TITLE
Handle rrule(f, x::T) where T

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesOverloadGeneration"
 uuid = "f51149dc-2911-5acf-81fc-2076a2a81d4f"
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ruleset_loading.jl
+++ b/src/ruleset_loading.jl
@@ -66,7 +66,8 @@ _is_fallback(::typeof(rrule), m::Method) = m.sig === Tuple{typeof(rrule),Any,Var
 _is_fallback(::typeof(frule), m::Method) = m.sig === Tuple{typeof(frule),Any,Any,Vararg{Any}}
 
 "check if this rule requires a particular configuation (`RuleConfig`)"
-_requires_config(m::Method) = m.sig.parameters[2] <: RuleConfig
+_requires_config(m::Method) = m.sig <: Tuple{Any, RuleConfig, Vararg}
+
 
 const LAST_REFRESH_RRULE = Ref(0)
 const LAST_REFRESH_FRULE = Ref(0)


### PR DESCRIPTION
the old way caused errors because `sig.parameters` can't be used if `sig` is a `UnionAll`