### PR TITLE
Don't return opted out rules. CRC 1.0 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "ChainRulesOverloadGeneration"
 uuid = "f51149dc-2911-5acf-81fc-2076a2a81d4f"
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [compat]
-ChainRulesCore = "0.10.4"
+ChainRulesCore = "1.0.0"
 julia = "1"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,12 @@ using ChainRulesOverloadGeneration
 using Test
 
 @testset "ChainRulesCore" begin
-    include("ruleset_loading.jl")
-
     @testset "demos" begin
         include("demos/forwarddiffzero.jl")
         include("demos/reversediffzero.jl")
     end
+
+    # Do this after demos run, so that the simple demo code doesn't have to handle 
+    # anything weird we define for testing purposes
+    include("ruleset_loading.jl")
 end


### PR DESCRIPTION
Partner to https://github.com/JuliaDiff/ChainRulesCore.jl/pull/398

This does not help one actually opt out of rules.
It doesn't expost an API for keeping track of that.
(But I think maybe we can exactly copy the one for frule/rrule?)
That can be a follow up PR.
It is less pressing

What it does do is make sure the rules that return nothing are not incuded in the list of rules that get generated.
Which means that opting out will not cause e,g. Nabla to generate a overload that hits a rule that returns `nothing`.