### PR TITLE
fix references to master in docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 # ChainRulesOverloadGeneration
 
 [![Build Status](https://github.com/JuliaDiff/ChainRulesOverloadGeneration.jl/workflows/CI/badge.svg)](https://github.com/JuliaDiff/ChainRulesOverloadGeneration.jl/actions?query=workflow:CI)
-[![Coverage](https://codecov.io/gh/JuliaDiff/ChainRulesOverloadGeneration.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDiff/ChainRulesOverloadGeneration.jl)
+[![Coverage](https://codecov.io/gh/JuliaDiff/ChainRulesOverloadGeneration.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaDiff/ChainRulesOverloadGeneration.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![DOI](https://zenodo.org/badge/199721843.svg)](https://zenodo.org/badge/latestdoi/199721843)
 
 **Docs:**
-[![](https://img.shields.io/badge/docs-master-blue.svg)](https://juliadiff.org/ChainRulesOverloadGeneration.jl/dev)
+[![](https://img.shields.io/badge/docs-main-blue.svg)](https://juliadiff.org/ChainRulesOverloadGeneration.jl/dev)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/ChainRulesOverloadGeneration.jl/stable)
 
 The ChainRulesOverloadGeneration package provides a suite of methods for using [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) rules in operator overloading AD systems.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,4 +29,5 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaDiff/ChainRulesOverloadGeneration.jl.git",
     push_preview=true,
+    devbranch="main",
 )


### PR DESCRIPTION
We are renaming to main.
This makes the docs keep building